### PR TITLE
Fix ubuntu check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -74,7 +74,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: [1.56.1] # 2021 edition requires 1.56
+        msrv: [1.65.0] # let...else requires 1.65.0
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The `ubuntu/1.56.1` check complains that it can't find `phf` version 11.1 in crates.io, but it's there https://crates.io/crates/phf

```
error: failed to select a version for the requirement `phf = "=0.11.1"`
candidate versions found which didn't match: 0.10.1, 0.10.0, 0.9.0, ...
location searched: crates.io index
required by package `tokio-postgres v0.7.8`
    ... which satisfies dependency `tokio-postgres = "=0.7.8"` of package `postgres v0.19.5`
    ... which satisfies dependency `postgres = "=0.19.5"` of package `bitcoin-scanner v0.1.0 (/home/runner/work/bitcoin-scanner/bitcoin-scanner)`
Error: Process completed with exit code 101.
```

I'm making an experiment to see if I can fix it.